### PR TITLE
Add handling of Github webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ production: clean install compile forever
 test: compile dist/test
 	FRIGG_WORKER_TOKEN=token $(ISTANBUL) cover $(MOCHA) dist/test
 
+mocha: compile dist/test
+	FRIGG_WORKER_TOKEN=token $(BIN)/mocha dist/test
+
 dist: $(SRC_FILES)
 	$(BAILEY) -c server
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "bailey": "0.0.17",
     "bluebird": "^2.9.15",
+    "body-parser": "^1.12.3",
     "express": "^4.11.2",
     "redis": "^0.12.1"
   },

--- a/src/app.bs
+++ b/src/app.bs
@@ -31,4 +31,5 @@ app.use('/fetch', (req, res, next) ->
 
 app.get('/fetch/:slug', routes.fetch)
 app.get('/fetch', routes.fetch)
+app.post('/webhooks/github', routes.webhooks.github)
 app.get('/*', routes.redirect)

--- a/src/app.bs
+++ b/src/app.bs
@@ -1,4 +1,5 @@
 import express
+import body-parser as bodyParser
 
 import ./config
 import ./routes
@@ -6,6 +7,7 @@ import ./routes
 export app
 
 app = express()
+app.use(bodyParser.json())
 
 app.use('/fetch', (req, res, next) ->
   if req.headers['x-frigg-worker-token'] != config.FRIGG_WORKER_TOKEN

--- a/src/controllers.bs
+++ b/src/controllers.bs
@@ -12,3 +12,14 @@ fetch = (slug) ->
       return client.rpopAsync('frigg:queue' + (slug ? ':#{slug}' : ''))
     )
     .then((job) -> JSON.parse(job))
+
+handleWebhook = (service, type, payload) ->
+  return client
+    .selectAsync(config.REDIS_DB)
+    .then(() ->
+        return client.lpushAsync('frigg:webhooks', JSON.stringify({
+          service: service
+          type: type
+          payload: payload
+        }))
+    )

--- a/src/routes.bs
+++ b/src/routes.bs
@@ -10,3 +10,16 @@ fetch = (req, res, next) ->
 
 redirect = (req, res) ->
   return res.redirect('http://frigg.io')
+
+webhooks = {
+  github: (req, res, next) ->
+    event = req.headers['x-github-event']
+    return controllers
+      .handleWebhook('github', event, req.body)
+      .then(() ->
+        res.status(202).send(
+          '"#{event}"-event put on queue, it will be handled eventually'
+        )
+      )
+      .catch(next)
+}

--- a/test/test-app.bs
+++ b/test/test-app.bs
@@ -18,7 +18,11 @@ describe('Express server', () ->
 
     return client
       .selectAsync(2)
-      .then(() -> client.delAsync('frigg:queue'))
+      .then(() -> bluebird.all([
+        client.delAsync('frigg:queue'),
+        client.delAsync('frigg:queue:custom'),
+        client.delAsync('frigg:webhooks'),
+      ]))
   )
 
   describe('/*', () ->
@@ -116,6 +120,38 @@ describe('Express server', () ->
         .then((res) ->
           expect(res.body.job.branch).to.equal('master')
           expect(res.body.job.clone_url).to.equal('url-custom')
+        )
+    )
+  )
+
+  describe('/webhooks/github', () ->
+    it('should return 202', () ->
+      return request(app)
+        .post('/webhooks/github')
+        .expectAsync(202)
+    )
+
+    it('should put payload on redis queue', () ->
+      payload = {'ref': 'refs/heads/master' 'after': 'ba6854eb994c433b48a3be20fc04cae93d6929a6'}
+
+      return request(app)
+        .post('/webhooks/github')
+        .set('X-Github-Event', 'push')
+        .send(payload)
+        .expect(202)
+        .endAsync()
+        .then((res) ->
+          return client.selectAsync(2)
+        )
+        .then(() ->
+          return client.lrangeAsync('frigg:webhooks', 0, -1)
+        )
+        .then((queue) ->
+          expect(queue.length).to.equal(1)
+          item = JSON.parse(queue[0])
+          expect(item.service).to.equal('github')
+          expect(item.type).to.equal('push')
+          expect(item.payload).to.eql(payload)
         )
     )
   )


### PR DESCRIPTION
Adds a endpoint `/webhooks/github` that puts the webhook payload on a redis queue.